### PR TITLE
Bump Docker version to 2025.1.0 and use latest LTS Ubuntu version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:20.04
-# Gallium: v16 and lts
-# bullseye: Debian Stable
+FROM ubuntu:24.04
+# jod: v22 and lts
+# bookworm: Debian Stable
 
 LABEL com.bitwarden.product="bitwarden"
 
@@ -13,7 +13,7 @@ ENV BITWARDENCLI_CONNECTOR_PLAINTEXT_SECRETS=true
 WORKDIR /app
 ENV PATH="/app:${PATH}"
 
-ARG BWDC_VERSION=2.9.10
+ARG BWDC_VERSION=2025.1.0
 ENV BWDC_VERSION=${BWDC_VERSION}
 
 RUN apt-get update \

--- a/docker.build.sh
+++ b/docker.build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-BWDC_VERSION=2.9.10
-export BUILD_TAG=bitwarden/directory-connector:${BWDC_VERSION}-containerise_v3.0.1
+BWDC_VERSION=2025.1.0
+export BUILD_TAG=bitwarden/directory-connector:${BWDC_VERSION}-containerise_v3.0.2
 
 
 DOCKER_BUILDKIT=1 docker build --progress=plain . --label com.bitwarden.product="bitwarden" --build-arg BWDC_VERSION -t ${BUILD_TAG} --rm #--no-cache # --squash --pull

--- a/dockerfiles/update-bwdc.sh
+++ b/dockerfiles/update-bwdc.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BWDC_VERSION=2.9.10
+BWDC_VERSION=2025.1.0
 
 echo "Work in progress, not executable yet! Exiting..."
 exit


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
* Bump Directory Connector version to 2025.1.0 (Latest)
* Use Ubuntu 24.04 instead of 20.04



## Code changes
Ubuntu 20.04 is now obsolete for a while, and I want to use the Docker container without any security breach



## Before you submit
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] I have added **unit tests** where it makes sense to do so (encouraged but not required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
